### PR TITLE
Added option to disable the WSDL mode of SoapServer

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -51,10 +51,6 @@ class Action extends \yii\base\Action
      */
     public $wsdlUrl;
     /**
-     * @var array
-     */
-    public $wsdlOptions = [];
-    /**
      * @var array a list of PHP classes that are declared as complex types in WSDL.
      * This should be an array with WSDL types as keys and names of PHP classes as values.
      * A PHP class can also be specified as a path alias.
@@ -115,8 +111,7 @@ class Action extends \yii\base\Action
             $this->_service = new Service([
                 'provider' => $this->provider,
                 'serviceUrl' => $this->serviceUrl,
-                'wsdlUrl' => $this->wsdlUrl,
-                'wsdlOptions' => $this->wsdlOptions,
+                'wsdlUrl' => $this->wsdlUrl
             ]);
             if (is_array($this->classMap)) {
                 $this->_service->classMap = $this->classMap;

--- a/README.md
+++ b/README.md
@@ -58,3 +58,22 @@ class ApiController extends Controller
     }
 }
 ```
+
+In case you want to disable the WSDL mode of SoapServer, you can specify this in the `serviceOptions` parameter as indicated below. You can use this when the request is to complex for the WSDL generator.
+
+```php
+    /**
+     * @inheritdoc
+     */
+    public function actions() {
+        return [
+            'index' => [
+                'class' => 'mongosoft\soapserver\Action',
+                'serviceOptions' => [
+                    'disableWsdlMode' => true
+                ]
+            ]
+        ];
+    }
+```
+

--- a/Service.php
+++ b/Service.php
@@ -35,9 +35,9 @@ class Service extends Component
      */
     public $wsdlUrl;
     /**
-     * @var array
+     * @var boolean indicating if the WSDL mode of SoapServer should be disabled.
      */
-    public $wsdlOptions = [];
+    public $disableWsdlMode = false;
     /**
      * @var Cache|array|string the cache object or the application component ID of the cache object.
      * The WSDL will be cached using this cache object. Note, this property has meaning only
@@ -147,7 +147,7 @@ class Service extends Component
     {
         header('Content-Type: text/xml;charset=' . $this->encoding);
 
-        if ($this->wsdlOptions['disableWsdlMode'] == true) {
+        if ($this->disableWsdlMode) {
             $server = new SoapServer(null, array_merge(['uri' => $this->serviceUrl], $this->getOptions()));
         } else {
             $server = new SoapServer($this->wsdlUrl, $this->getOptions());

--- a/Service.php
+++ b/Service.php
@@ -147,7 +147,11 @@ class Service extends Component
     {
         header('Content-Type: text/xml;charset=' . $this->encoding);
 
-        $server = new SoapServer($this->wsdlUrl, $this->getOptions());
+        if ($this->wsdlOptions['disableWsdlMode'] == true) {
+            $server = new SoapServer(null, array_merge(array('uri' => $this->serviceUrl), $this->getOptions()));
+        } else {
+            $server = new SoapServer($this->wsdlUrl, $this->getOptions());
+        }
         try {
             if ($this->persistence !== null) {
                 $server->setPersistence($this->persistence);

--- a/Service.php
+++ b/Service.php
@@ -148,7 +148,7 @@ class Service extends Component
         header('Content-Type: text/xml;charset=' . $this->encoding);
 
         if ($this->wsdlOptions['disableWsdlMode'] == true) {
-            $server = new SoapServer(null, array_merge(array('uri' => $this->serviceUrl), $this->getOptions()));
+            $server = new SoapServer(null, array_merge(['uri' => $this->serviceUrl], $this->getOptions()));
         } else {
             $server = new SoapServer($this->wsdlUrl, $this->getOptions());
         }


### PR DESCRIPTION
I'm using the wsdlOptions array to pass the option to the Service object. I'm not sure if that's a valid use for that, but it isn't used for anything else.

In non-wsdl mode, an URI is also required, so that gets added along with the other options.
