### PR TITLE
Change License to MIT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php-versions:
-          - 7.4
           - 8.0
           - 8.1
           - 8.2

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 SOAP Server Extension for Yii 2
-==============================
+===============================
 
 Note, PHP SOAP extension is required.
 
-[![Latest Stable Version](https://poser.pugx.org/mongosoft/yii2-soap-server/v/stable.png)](https://packagist.org/packages/mongosoft/yii2-soap-server)
+[![Latest Stable Version](https://poser.pugx.org/mongosoft/yii2-soap-server/v/stable.png)](https://github.com/mohorev/yii2-soap-server/releases)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](docs/LICENSE.md)
+[![Build Status](https://github.com/mohorev/yii2-soap-server/actions/workflows/build.yml/badge.svg)](https://github.com/mohorev/yii2-soap-server/actions/workflows/build.yml)
 [![Total Downloads](https://poser.pugx.org/mongosoft/yii2-soap-server/downloads.png)](https://packagist.org/packages/mongosoft/yii2-soap-server)
-[![Build Status](https://travis-ci.org/mongosoft/yii2-soap-server.png)](https://travis-ci.org/mongosoft/yii2-soap-server)
 
 Installation
 ------------
@@ -79,3 +80,21 @@ You can use this when the request is to complex for the WSDL generator.
     }
 ```
 
+Testing
+-------
+
+``` bash
+$ vendor/bin/codecept run Unit
+```
+
+## Contributing
+
+Please see [CONTRIBUTING](docs/CONTRIBUTING.md) for details.
+
+## Security
+
+If you discover any security related issues, please email instead of using the issue tracker.
+
+## License
+
+The MIT License (MIT). Please see [License File](docs/LICENSE.md) for more information.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "homepage": "https://github.com/mongosoft/yii2-soap-server",
     "type": "yii2-extension",
-    "license": "BSD-3-Clause",
+    "license": "MIT",
     "support": {
         "issues": "https://github.com/mongosoft/yii2-soap-server/issues?state=open",
         "source": "https://github.com/mongosoft/yii2-soap-server"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+We accept contributions via Pull Requests on [Github](https://github.com/mohorev/yii2-soap-server).
+
+
+## Pull Requests
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+
+- **Create feature branches** - Don't ask us to pull from your master branch.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please squash them before submitting.
+
+
+## Running Tests
+
+``` bash
+$ vendor/bin/codecept run Unit
+```
+
+
+**Happy coding**!

--- a/docs/LICENSE.md
+++ b/docs/LICENSE.md
@@ -1,0 +1,22 @@
+# The MIT License (MIT)
+
+Copyright (c) 2011-2017 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tests/Unit/Controller.php
+++ b/tests/Unit/Controller.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mongosoft\soapserver\tests\unit;
+namespace mongosoft\soapserver\tests\Unit;
 
 class Controller
 {

--- a/tests/Unit/ServiceTest.php
+++ b/tests/Unit/ServiceTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit;
 
 use Tests\Support\UnitTester;
 use mongosoft\soapserver\Service;
-use mongosoft\soapserver\tests\unit\Controller;
+use mongosoft\soapserver\tests\Unit\Controller;
 use SimpleXMLElement;
 
 class ServiceTest extends \Codeception\Test\Unit


### PR DESCRIPTION
Repair GitHub workflows to check only PHP versions greater or igual than 8.0 (required by codeception 5)